### PR TITLE
docs(README): Reference the gh-pages branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # maven-repository
 Maven repository for SORACOM products
+
+Packages are served with GitHub Pages, in the
+[gh-pages](https://github.com/soracom/maven-repository/tree/gh-pages) branch.


### PR DESCRIPTION
The gh-pages branch contains the actual content of the repo. This repository is not empty.